### PR TITLE
Fix dist info metadata

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+# Prefer pyenv over the python3 layout
+#   Requires use_pyenv() to be defined in ~/.config/direnv/direnvrc
+#   see: https://github.com/direnv/direnv/wiki/Python#pyenv
+
+if has pyenv; then
+  layout pyenv 3.9.11
+else
+  layout python
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dmypy.json
 .pyre/
 
 .DS_Store
+
+.direnv/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ If you are deploying `serverless-pypi` stand-alone, you will need to provision a
 | LOGGING_LEVEL | N | Sets the logging level for the Lambda function | INFO |
 | UPSTREAM_INDEX_URL | N | The url underlying PyPI repository to mirror. This may contain credentialing information. | https://pypi.org/simple/ |
 | REPO_BASE_PREFIX | N | The prefix to use in the S3 bucket. | "" |
+| HASH_DIST_INFO_METADATA | N | Whether to hash the `dist-info-metadata`. Defaults to `"0"` since it seems like having the hash may cause `LinkHash: "unhashable type 'dict'"` error on pip>=22.3 and above. | "0" |
 
 ### IAM Permissions
 | Permission | Resource | Note |

--- a/src/lambda_function/function.py
+++ b/src/lambda_function/function.py
@@ -74,6 +74,7 @@ DIST_EXTENSIONS = {
     ".whl": "application/octet-stream",
     ".zip": "application/zip",
 }
+HASH_DIST_INFO_METADATA = environ.get("HASH_DIST_INFO_METADATA", "0")
 HTTP_BASIC = HTTPBasic()
 LAMBDA_CLIENT: LambdaClient = None
 LATEST_RE = re.compile(r"latest")
@@ -767,8 +768,14 @@ async def upload_project_file(
         ContentType="text/plain",
         Key=project_file_params["Key"] + ".metadata",
     )
+
+    if HASH_DIST_INFO_METADATA == "1":
+        dist_info_metadata = dict(sha256=sha256(metadata).hexdigest())
+    else:
+        dist_info_metadata = "true"
+
     project_file_obj = {
-        "dist-info-metadata": dict(sha256=sha256(metadata).hexdigest()),
+        "dist-info-metadata": dist_info_metadata,
         "filename": project_file.filename,
         "hashes": {
             cast(str, key).split("_")[0]: value


### PR DESCRIPTION
Due to [PEP 658](https://peps.python.org/pep-0658/), we need to update `dist_info_metadata` to be able to support either the hash of metadata, or simply `true`. 

This PR introduces changes that reads a new environment variable `HASH_DIST_INFO_METADATA` which changes the behaviour of the pypi server; if set to `0`, it simply uses `dist_info_metadata=true`, otherwise it will pass the hash value to `dist_info_metadata`.

Defaults to `"0"`, since it seems like having the hash may cause `LinkHash: "unhashable type 'dict'"` error on pip>=22.3 and above.