### PR TITLE
Expand api version constraint to 1.xx

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,7 +4,7 @@ beautifulsoup4
 black
 boto3
 boto3-stubs[lambda,s3]
-fastapi
+fastapi<0.89.0
 mangum
 orjson
 passlib

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,7 +8,7 @@ fastapi
 mangum
 orjson
 passlib
-pydantic
+pydantic<2
 python-multipart
 requests
 uvicorn

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ lambda_install_requires = [
     "aws-error-utils",
     "backoff",
     "beautifulsoup4",
-    "fastapi",
+    "fastapi<0.89.0",
     "mangum",
     "orjson",
     "passlib",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ lambda_install_requires = [
     "mangum",
     "orjson",
     "passlib",
-    "pydantic",
+    "pydantic<2",
     "python-multipart",
     "requests",
 ]

--- a/src/lambda_function/function.py
+++ b/src/lambda_function/function.py
@@ -139,7 +139,7 @@ class PyPIMeta(BaseModel, json_dumps=orjson_dumps, json_loads=orjson.loads):
 
     @validator("api_version")
     def api_version_validator(cls, value: str) -> str:
-        if value != "1.0":
+        if not re.match(r"1\.[0-9]+", value):
             raise ValueError(f"Received an unknown 'api-version': {value}")
         return value
 


### PR DESCRIPTION
Hi folks!

I tried using serverless-pypi 0.0.6 yesterday and discovered it doesn't support the current PyPI as an upstream since it's now returning `api-version="1.3"` instead of `"1.0"` as expected by the current code.

I just tested expanding the constraint to "1.xx" via a regex as can be seen in this PR, and that seems to be working correctly.

While testing, I had also discovered that new versions of Pydantic and FastAPI are incompatible with serverless-pypi=0.0.6, so I added some version constraints that seem to be the least restrictive while getting the code to work:

- Pydantic 2 breaks using `json_dumps`, `json_loads` in class definitions
- [FastAPI 0.89.0 uses function return type annotations](https://fastapi.tiangolo.com/release-notes/#0890) to infer response_model and that breaks on `Optional[Response]`

I'd really appreciate y'all merging this and publishing a new version, and thanks a lot for this useful project! 